### PR TITLE
use C++17

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.2)
 project(graph_rviz_plugin)
 add_compile_options(-Wall -Wextra)
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 ## Find catkin macros and libraries


### PR DESCRIPTION
This cleans up a build error on newer systems including 22.04 using more recent log4cxx, and should still be fine on melodic and noetic.

```
/usr/include/log4cxx/boost-std-configuration.h:10:13: note: ‘std::shared_mutex’ is only available from C++17 onwards
```